### PR TITLE
feat: exercise to handle event in ShoppingCart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea
+!.idea/
+.idea/*
+!.idea/runConfigurations/Run_locally.xml
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# VSCode
+.vscode
+
+# Maven
+log/
+target/
+effective-pom.xml
+
+#local db
+db.mv.db

--- a/Exercises/2_begin/akkazon/src/test/java/shoppingcart/ShoppingCartTest.java
+++ b/Exercises/2_begin/akkazon/src/test/java/shoppingcart/ShoppingCartTest.java
@@ -51,4 +51,64 @@ class ShoppingCartTest {
         assertTrue(emptyCart.items().isEmpty());
         assertFalse(emptyCart.checkedOut());
     }
+
+    // --- Tests for onItemAdded ---
+
+    @Test
+    void itemIsAddedToEmptyCart() {
+        var cart = new ShoppingCart("cart-1", List.of(), false);
+        var item = new ShoppingCart.LineItem("p1", "Akka Hoodie", 2);
+        var event = new ShoppingCartEvent.ItemAdded(item);
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(1, updatedCart.items().size());
+        assertEquals("p1", updatedCart.items().get(0).productId());
+        assertEquals(2, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void itemQuantityIsIncreasedWhenAlreadyInCart() {
+        var existingItem = new ShoppingCart.LineItem("p1", "Akka Hoodie", 2);
+        var cart = new ShoppingCart("cart-1", List.of(existingItem), false);
+
+        var additional = new ShoppingCart.LineItem("p1", "Akka Hoodie", 3);
+        var event = new ShoppingCartEvent.ItemAdded(additional);
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(1, updatedCart.items().size());
+        assertEquals("p1", updatedCart.items().get(0).productId());
+        assertEquals(5, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void cartImmutabilityIsPreserved() {
+        var existingItem = new ShoppingCart.LineItem("p1", "Akka Hoodie", 1);
+        var originalCart = new ShoppingCart("cart-1", List.of(existingItem), false);
+
+        var event = new ShoppingCartEvent.ItemAdded(
+            new ShoppingCart.LineItem("p1", "Akka Hoodie", 1));
+
+        var updatedCart = originalCart.onItemAdded(event);
+
+        // Original cart should remain unchanged
+        assertEquals(1, originalCart.items().get(0).quantity());
+        assertEquals(2, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void itemsAreSortedByProductId() {
+        var itemA = new ShoppingCart.LineItem("b-product", "Blue Jeans", 1);
+        var cart = new ShoppingCart("cart-1", List.of(itemA), false);
+
+        var event = new ShoppingCartEvent.ItemAdded(
+            new ShoppingCart.LineItem("a-product", "Akka Hoodie", 2));
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(2, updatedCart.items().size());
+        assertEquals("a-product", updatedCart.items().get(0).productId());
+        assertEquals("b-product", updatedCart.items().get(1).productId());
+    }
 }

--- a/Exercises/2_end/akkazon/src/main/java/shoppingcart/domain/ShoppingCart.java
+++ b/Exercises/2_end/akkazon/src/main/java/shoppingcart/domain/ShoppingCart.java
@@ -1,6 +1,9 @@
 package shoppingcart.domain;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.stream.Collectors;
 
 public record ShoppingCart(String cartId, List<LineItem> items, boolean checkedOut) {
 
@@ -10,4 +13,25 @@ public record ShoppingCart(String cartId, List<LineItem> items, boolean checkedO
         }
     }
 
+    public ShoppingCart onItemAdded(ShoppingCartEvent.ItemAdded itemAdded) {
+        var item = itemAdded.item();
+
+        // Update quantity if item already exists
+        LineItem updatedItem = items.stream()
+            .filter(i -> i.productId().equals(item.productId()))
+            .findFirst()
+            .map(existing -> existing.withQuantity(existing.quantity() + item.quantity()))
+            .orElse(item);
+
+        // Remove any preexisting item with the same productId
+        List<LineItem> updatedItems = items.stream()
+            .filter(i -> !i.productId().equals(item.productId()))
+            .collect(Collectors.toList());
+
+        // Add the updated item and sort the list
+        updatedItems.add(updatedItem);
+        updatedItems.sort(Comparator.comparing(LineItem::productId));
+
+        return new ShoppingCart(cartId, updatedItems, checkedOut);
+    }
 }

--- a/Exercises/2_end/akkazon/src/test/java/shoppingcart/domain/ShoppingCartTest.java
+++ b/Exercises/2_end/akkazon/src/test/java/shoppingcart/domain/ShoppingCartTest.java
@@ -51,4 +51,64 @@ class ShoppingCartTest {
         assertTrue(emptyCart.items().isEmpty());
         assertFalse(emptyCart.checkedOut());
     }
+
+    // --- Tests for onItemAdded ---
+
+    @Test
+    void itemIsAddedToEmptyCart() {
+        var cart = new ShoppingCart("cart-1", List.of(), false);
+        var item = new ShoppingCart.LineItem("p1", "Akka Hoodie", 2);
+        var event = new ShoppingCartEvent.ItemAdded(item);
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(1, updatedCart.items().size());
+        assertEquals("p1", updatedCart.items().get(0).productId());
+        assertEquals(2, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void itemQuantityIsIncreasedWhenAlreadyInCart() {
+        var existingItem = new ShoppingCart.LineItem("p1", "Akka Hoodie", 2);
+        var cart = new ShoppingCart("cart-1", List.of(existingItem), false);
+
+        var additional = new ShoppingCart.LineItem("p1", "Akka Hoodie", 3);
+        var event = new ShoppingCartEvent.ItemAdded(additional);
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(1, updatedCart.items().size());
+        assertEquals("p1", updatedCart.items().get(0).productId());
+        assertEquals(5, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void cartImmutabilityIsPreserved() {
+        var existingItem = new ShoppingCart.LineItem("p1", "Akka Hoodie", 1);
+        var originalCart = new ShoppingCart("cart-1", List.of(existingItem), false);
+
+        var event = new ShoppingCartEvent.ItemAdded(
+            new ShoppingCart.LineItem("p1", "Akka Hoodie", 1));
+
+        var updatedCart = originalCart.onItemAdded(event);
+
+        // Original cart should remain unchanged
+        assertEquals(1, originalCart.items().get(0).quantity());
+        assertEquals(2, updatedCart.items().get(0).quantity());
+    }
+
+    @Test
+    void itemsAreSortedByProductId() {
+        var itemA = new ShoppingCart.LineItem("b-product", "Blue Jeans", 1);
+        var cart = new ShoppingCart("cart-1", List.of(itemA), false);
+
+        var event = new ShoppingCartEvent.ItemAdded(
+            new ShoppingCart.LineItem("a-product", "Akka Hoodie", 2));
+
+        var updatedCart = cart.onItemAdded(event);
+
+        assertEquals(2, updatedCart.items().size());
+        assertEquals("a-product", updatedCart.items().get(0).productId());
+        assertEquals("b-product", updatedCart.items().get(1).productId());
+    }
 }


### PR DESCRIPTION
Add onItemAdded() method to ShoppingCart in the 2_end exercise to apply ItemAdded events immutably and sort items by productId.

Update tests in 2_begin and 2_end to validate event handling and behavior.

Add .gitignore with common IDE and Maven rules.

Refs: lightbend/kalix#13062